### PR TITLE
fix: Remove client read message timeout

### DIFF
--- a/internal/client/main.go
+++ b/internal/client/main.go
@@ -113,11 +113,6 @@ func (mc *MmarClient) ProcessTunnelMessages(ctx context.Context) {
 		case <-ctx.Done(): // Client gracefully shutdown
 			return
 		default:
-			// Set read deadline to half the graceful shutdown timeout to
-			// allow detections of graceful shutdowns
-			readDeadline := time.Now().Add((constants.GRACEFUL_SHUTDOWN_TIMEOUT / 2) * time.Second)
-			mc.Tunnel.Conn.SetReadDeadline(readDeadline)
-
 			tunnelMsg, err := mc.ReceiveMessage()
 			if err != nil {
 				if errors.Is(err, io.EOF) {


### PR DESCRIPTION
When a TunnelMessage that is large coming from the server the Conn in ReceiveMessage would sometimes timeout on read. This timeout was initially added to check if the client has been shutdown gracefully, but that caused more issues than needed. So we fall back to the client connection being shutdown from the server when the client is shutdown by the user.