### PR TITLE
fix: Missing query params in tunneled request

### DIFF
--- a/internal/server/utils.go
+++ b/internal/server/utils.go
@@ -65,7 +65,7 @@ func serializeRequest(ctx context.Context, r *http.Request, cancel context.Cance
 		fmt.Sprintf(
 			"%v %v %v\nHost: %v\n",
 			r.Method,
-			r.URL.Path,
+			r.RequestURI,
 			r.Proto,
 			r.Host,
 		),

--- a/simulations/devserver/main.go
+++ b/simulations/devserver/main.go
@@ -55,12 +55,14 @@ func setupMux() *http.ServeMux {
 }
 
 func handleGet(w http.ResponseWriter, r *http.Request) {
-	// Include echo of request headers in response to confirm they were received
+	// Include echo of request headers and query params in response to
+	// confirm they were received
 	respBody, err := json.Marshal(map[string]interface{}{
 		"success": true,
 		"data":    "some data",
 		"echo": map[string]interface{}{
-			"reqHeaders": r.Header,
+			"reqHeaders":     r.Header,
+			"reqQueryParams": r.URL.Query(),
 		},
 	})
 

--- a/simulations/simulation_test.go
+++ b/simulations/simulation_test.go
@@ -107,6 +107,12 @@ func verifyGetRequestSuccess(t *testing.T, client *http.Client, tunnelUrl string
 	// Adding custom header to confirm that they are propogated when going through mmar
 	req.Header.Set("Simulation-Test", "verify-get-request-success")
 
+	// Adding query params to confirm that they get propogated when going through mmar
+	q := req.URL.Query()
+	q.Add("first", "query param")
+	q.Add("second", "param & last")
+	req.URL.RawQuery = q.Encode()
+
 	resp, respErr := client.Do(req)
 	if respErr != nil {
 		log.Printf("Failed to get response: %v", respErr)
@@ -122,7 +128,8 @@ func verifyGetRequestSuccess(t *testing.T, client *http.Client, tunnelUrl string
 		"success": true,
 		"data":    "some data",
 		"echo": map[string]interface{}{
-			"reqHeaders": expectedReqHeaders,
+			"reqHeaders":     expectedReqHeaders,
+			"reqQueryParams": q,
 		},
 	}
 	marshaledBody, _ := json.Marshal(expectedBody)
@@ -326,7 +333,8 @@ func verifyRedirectsHandled(t *testing.T, client *http.Client, tunnelUrl string,
 		"success": true,
 		"data":    "some data",
 		"echo": map[string]interface{}{
-			"reqHeaders": expectedReqHeaders,
+			"reqHeaders":     expectedReqHeaders,
+			"reqQueryParams": map[string][]string{},
 		},
 	}
 	marshaledBody, _ := json.Marshal(expectedBody)
@@ -377,7 +385,8 @@ func verifyInvalidMethodRequestHandled(t *testing.T, client *http.Client, tunnel
 		"success": true,
 		"data":    "some data",
 		"echo": map[string]interface{}{
-			"reqHeaders": expectedReqHeaders,
+			"reqHeaders":     expectedReqHeaders,
+			"reqQueryParams": map[string][]string{},
 		},
 	}
 	marshaledBody, _ := json.Marshal(expectedBody)


### PR DESCRIPTION
Include the full requestURI when serializing the request.