### PR TITLE
feat: Add heartbeats between server and clients

### DIFF
--- a/constants/main.go
+++ b/constants/main.go
@@ -23,18 +23,21 @@ const (
 	CLIENT_TCP_PORT_HELP   = "Define port of mmar TCP server for client to connect to, creating a tunnel."
 	TUNNEL_HOST_HELP       = "Define host domain of mmar server for client to connect to."
 
-	TUNNEL_MESSAGE_PROTOCOL_VERSION = 1
+	TUNNEL_MESSAGE_PROTOCOL_VERSION = 2
 	TUNNEL_MESSAGE_DATA_DELIMITER   = '\n'
 	ID_CHARSET                      = "abcdefghijklmnopqrstuvwxyz0123456789"
 	ID_LENGTH                       = 6
 
-	MAX_TUNNELS_PER_IP          = 5
-	TUNNEL_RECONNECT_TIMEOUT    = 3
-	GRACEFUL_SHUTDOWN_TIMEOUT   = 3
-	TUNNEL_CREATE_TIMEOUT       = 3
-	REQ_BODY_READ_CHUNK_TIMEOUT = 3
-	DEST_REQUEST_TIMEOUT        = 30
-	MAX_REQ_BODY_SIZE           = 10000000 // 10mb
+	MAX_TUNNELS_PER_IP            = 5
+	TUNNEL_RECONNECT_TIMEOUT      = 3
+	GRACEFUL_SHUTDOWN_TIMEOUT     = 3
+	TUNNEL_CREATE_TIMEOUT         = 3
+	REQ_BODY_READ_CHUNK_TIMEOUT   = 3
+	DEST_REQUEST_TIMEOUT          = 30
+	HEARTBEAT_FROM_SERVER_TIMEOUT = 5
+	HEARTBEAT_FROM_CLIENT_TIMEOUT = 2
+	READ_DEADLINE                 = 3
+	MAX_REQ_BODY_SIZE             = 10000000 // 10mb
 
 	CLIENT_DISCONNECT_ERR_TEXT                    = "Tunnel is closed, cannot connect to mmar client."
 	LOCALHOST_NOT_RUNNING_ERR_TEXT                = "Tunneled successfully, but nothing is running on localhost."

--- a/internal/protocol/main.go
+++ b/internal/protocol/main.go
@@ -25,6 +25,9 @@ const (
 	CLIENT_TUNNEL_LIMIT
 	LOCALHOST_NOT_RUNNING
 	DEST_REQUEST_TIMEDOUT
+	HEARTBEAT_FROM_CLIENT
+	HEARTBEAT_FROM_SERVER
+	HEARTBEAT_ACK
 )
 
 var INVALID_MESSAGE_PROTOCOL_VERSION = errors.New("Invalid Message Protocol Version")
@@ -33,7 +36,7 @@ var INVALID_MESSAGE_TYPE = errors.New("Invalid Tunnel Message Type")
 func isValidTunnelMessageType(mt uint8) (uint8, error) {
 	// Iterate through all the message type, from first to last, checking
 	// if the provided message type matches one of them
-	for msgType := REQUEST; msgType <= DEST_REQUEST_TIMEDOUT; msgType++ {
+	for msgType := REQUEST; msgType <= HEARTBEAT_ACK; msgType++ {
 		if mt == msgType {
 			return msgType, nil
 		}

--- a/internal/utils/main.go
+++ b/internal/utils/main.go
@@ -112,5 +112,6 @@ func NetworkError(err error) bool {
 	return errors.Is(err, io.EOF) ||
 		errors.Is(err, io.ErrUnexpectedEOF) ||
 		errors.Is(err, net.ErrClosed) ||
-		errors.Is(err, syscall.ECONNRESET)
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, os.ErrDeadlineExceeded)
 }


### PR DESCRIPTION
Adding heartbeats as a means to determine if the connection between the client and the server is still alive and vice versa. This should allow for better handling for states when they get disconnected, additionally being able to determine if that is the case quicker.

This change updates the mmar Message Protocol.