### PR TITLE
fix: Properly handle invalid resp from dest server

### DIFF
--- a/constants/main.go
+++ b/constants/main.go
@@ -23,7 +23,7 @@ const (
 	CLIENT_TCP_PORT_HELP   = "Define port of mmar TCP server for client to connect to, creating a tunnel."
 	TUNNEL_HOST_HELP       = "Define host domain of mmar server for client to connect to."
 
-	TUNNEL_MESSAGE_PROTOCOL_VERSION = 2
+	TUNNEL_MESSAGE_PROTOCOL_VERSION = 3
 	TUNNEL_MESSAGE_DATA_DELIMITER   = '\n'
 	ID_CHARSET                      = "abcdefghijklmnopqrstuvwxyz0123456789"
 	ID_LENGTH                       = 6

--- a/internal/client/main.go
+++ b/internal/client/main.go
@@ -93,7 +93,11 @@ func (mc *MmarClient) handleRequestMessage(tunnelMsg protocol.TunnelMessage) {
 			return
 		}
 
-		log.Fatalf("Failed to forward: %v", fwdErr)
+		invalidRespFromDestMsg := protocol.TunnelMessage{MsgType: protocol.INVALID_RESP_FROM_DEST}
+		if err := mc.SendMessage(invalidRespFromDestMsg); err != nil {
+			log.Fatal(err)
+		}
+		return
 	}
 
 	logger.LogHTTP(req, resp.StatusCode, resp.ContentLength, false, true)
@@ -118,7 +122,7 @@ func (mc *MmarClient) reconnectTunnel(ctx context.Context) {
 		logger.Log(constants.DEFAULT_COLOR, "Attempting to reconnect...")
 		conn, err := net.DialTimeout(
 			"tcp",
-			fmt.Sprintf("%s:%s", mc.ConfigOptions.TunnelHost, mc.ConfigOptions.TunnelTcpPort),
+			net.JoinHostPort(mc.ConfigOptions.TunnelHost, mc.ConfigOptions.TunnelTcpPort),
 			constants.TUNNEL_CREATE_TIMEOUT*time.Second,
 		)
 		if err != nil {
@@ -229,7 +233,7 @@ func Run(config ConfigOptions) {
 
 	conn, err := net.DialTimeout(
 		"tcp",
-		fmt.Sprintf("%s:%s", config.TunnelHost, config.TunnelTcpPort),
+		net.JoinHostPort(config.TunnelHost, config.TunnelTcpPort),
 		constants.TUNNEL_CREATE_TIMEOUT*time.Second,
 	)
 	if err != nil {

--- a/internal/protocol/main.go
+++ b/internal/protocol/main.go
@@ -28,6 +28,7 @@ const (
 	HEARTBEAT_FROM_CLIENT
 	HEARTBEAT_FROM_SERVER
 	HEARTBEAT_ACK
+	INVALID_RESP_FROM_DEST
 )
 
 var INVALID_MESSAGE_PROTOCOL_VERSION = errors.New("Invalid Message Protocol Version")
@@ -36,7 +37,7 @@ var INVALID_MESSAGE_TYPE = errors.New("Invalid Tunnel Message Type")
 func isValidTunnelMessageType(mt uint8) (uint8, error) {
 	// Iterate through all the message type, from first to last, checking
 	// if the provided message type matches one of them
-	for msgType := REQUEST; msgType <= HEARTBEAT_ACK; msgType++ {
+	for msgType := REQUEST; msgType <= INVALID_RESP_FROM_DEST; msgType++ {
 		if mt == msgType {
 			return msgType, nil
 		}
@@ -48,9 +49,10 @@ func isValidTunnelMessageType(mt uint8) (uint8, error) {
 func TunnelErrState(errState uint8) string {
 	// TODO: Have nicer/more elaborative error messages/pages
 	errStates := map[uint8]string{
-		CLIENT_DISCONNECT:     constants.CLIENT_DISCONNECT_ERR_TEXT,
-		LOCALHOST_NOT_RUNNING: constants.LOCALHOST_NOT_RUNNING_ERR_TEXT,
-		DEST_REQUEST_TIMEDOUT: constants.DEST_REQUEST_TIMEDOUT_ERR_TEXT,
+		CLIENT_DISCONNECT:      constants.CLIENT_DISCONNECT_ERR_TEXT,
+		LOCALHOST_NOT_RUNNING:  constants.LOCALHOST_NOT_RUNNING_ERR_TEXT,
+		DEST_REQUEST_TIMEDOUT:  constants.DEST_REQUEST_TIMEDOUT_ERR_TEXT,
+		INVALID_RESP_FROM_DEST: constants.READ_RESP_BODY_ERR_TEXT,
 	}
 	fallbackErr := "An error occured while attempting to tunnel."
 

--- a/internal/server/main.go
+++ b/internal/server/main.go
@@ -461,29 +461,13 @@ func (ms *MmarServer) processTunnelMessages(ct *ClientTunnel) {
 		case protocol.LOCALHOST_NOT_RUNNING:
 			// Create a response for Tunnel connected but localhost not running
 			errState := protocol.TunnelErrState(protocol.LOCALHOST_NOT_RUNNING)
-			resp := http.Response{
-				Status:     "200 OK",
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewBufferString(errState)),
-			}
-
-			// Writing response to buffer to tunnel it back
-			var responseBuff bytes.Buffer
-			resp.Write(&responseBuff)
+			responseBuff := createSerializedServerResp("200 OK", http.StatusOK, errState)
 			notRunningMsg := protocol.TunnelMessage{MsgType: protocol.RESPONSE, MsgData: responseBuff.Bytes()}
 			ct.outgoingChannel <- notRunningMsg
 		case protocol.DEST_REQUEST_TIMEDOUT:
 			// Create a response for Tunnel connected but localhost took too long to respond
 			errState := protocol.TunnelErrState(protocol.DEST_REQUEST_TIMEDOUT)
-			resp := http.Response{
-				Status:     "200 OK",
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewBufferString(errState)),
-			}
-
-			// Writing response to buffer to tunnel it back
-			var responseBuff bytes.Buffer
-			resp.Write(&responseBuff)
+			responseBuff := createSerializedServerResp("200 OK", http.StatusOK, errState)
 			destTimedoutMsg := protocol.TunnelMessage{MsgType: protocol.RESPONSE, MsgData: responseBuff.Bytes()}
 			ct.outgoingChannel <- destTimedoutMsg
 		case protocol.CLIENT_DISCONNECT:
@@ -545,6 +529,12 @@ func (ms *MmarServer) processTunnelMessages(ct *ClientTunnel) {
 					existingId,
 				),
 			)
+		case protocol.INVALID_RESP_FROM_DEST:
+			// Create a response for receiving invalid response from destination server
+			errState := protocol.TunnelErrState(protocol.INVALID_RESP_FROM_DEST)
+			responseBuff := createSerializedServerResp("500 Internal Server Error", http.StatusInternalServerError, errState)
+			invalidRespFromDestMsg := protocol.TunnelMessage{MsgType: protocol.RESPONSE, MsgData: responseBuff.Bytes()}
+			ct.outgoingChannel <- invalidRespFromDestMsg
 		}
 	}
 }


### PR DESCRIPTION
This fix properly handles case when destination server returns an invalid or malformed http response, preventing mmar client from crashing and informing the user to check the destination server's logs.