### PR TITLE
Add -local-host and -local-proto flags for nginx virtual hosts proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ brew upgrade yusuf-musleh/mmar-tap/mmar
 
 ### Docker
 
-The fastest way to create a tunnel what is running on your `localhost:8080` using [Docker](https://www.docker.com/) is by running this command:
+The fastest way to create a tunnel what is running on your `https://project.test:443` using [Docker](https://www.docker.com/) is by running this command:
 
 ```
-docker run --rm --network host ghcr.io/yusuf-musleh/mmar:v0.2.6 client --local-port 8080
+docker run --rm --network host ghcr.io/yusuf-musleh/mmar:v0.2.6 client --local-proto https --local-host project.test --local-port 443
 ```
 
 ### Windows
@@ -133,6 +133,8 @@ You can define the various mmar command flags in environment variables rather th
 MMAR__SERVER_HTTP_PORT     -> mmar server --http-port
 MMAR__SERVER_TCP_PORT      -> mmar server --tcp-port
 MMAR__LOCAL_PORT           -> mmar client --local-port
+MMAR__LOCAL_HOST           -> mmar client --local-host
+MMAR__LOCAL_PROTO          -> mmar client --local-proto
 MMAR__TUNNEL_HTTP_PORT     -> mmar client --tunnel-http-port
 MMAR__TUNNEL_TCP_PORT      -> mmar client --tunnel-tcp-port
 MMAR__TUNNEL_HOST          -> mmar client --tunnel-host

--- a/cmd/mmar/main.go
+++ b/cmd/mmar/main.go
@@ -30,6 +30,16 @@ func main() {
 		utils.EnvVarOrDefault(constants.MMAR_ENV_VAR_LOCAL_PORT, constants.CLIENT_LOCAL_PORT),
 		constants.CLIENT_LOCAL_PORT_HELP,
 	)
+	clientLocalHost := clientCmd.String(
+		"local-host",
+		utils.EnvVarOrDefault(constants.MMAR_ENV_VAR_LOCAL_HOST, constants.CLIENT_LOCAL_HOST),
+		constants.CLIENT_LOCAL_HOST_HELP,
+	)
+	clientLocalProto := clientCmd.String(
+		"local-proto",
+		utils.EnvVarOrDefault(constants.MMAR_ENV_VAR_LOCAL_PROTO, constants.CLIENT_LOCAL_PROTO),
+		constants.CLIENT_LOCAL_PROTO_HELP,
+	)
 	clientTunnelHttpPort := clientCmd.String(
 		"tunnel-http-port",
 		utils.EnvVarOrDefault(constants.MMAR_ENV_VAR_TUNNEL_HTTP_PORT, constants.TUNNEL_HTTP_PORT),
@@ -68,6 +78,8 @@ func main() {
 		clientCmd.Parse(os.Args[2:])
 		mmarClientConfig := client.ConfigOptions{
 			LocalPort:      *clientLocalPort,
+			LocalHost:      *clientLocalHost,
+			LocalProto:     *clientLocalProto,
 			TunnelHttpPort: *clientTunnelHttpPort,
 			TunnelTcpPort:  *clientTunnelTcpPort,
 			TunnelHost:     *clientTunnelHost,

--- a/constants/main.go
+++ b/constants/main.go
@@ -3,18 +3,22 @@ package constants
 const (
 	MMAR_VERSION = "0.2.6"
 
-	VERSION_CMD       = "version"
-	SERVER_CMD        = "server"
-	CLIENT_CMD        = "client"
-	CLIENT_LOCAL_PORT = "8000"
-	SERVER_HTTP_PORT  = "3376"
-	SERVER_TCP_PORT   = "6673"
-	TUNNEL_HOST       = "mmar.dev"
-	TUNNEL_HTTP_PORT  = "443"
+	VERSION_CMD        = "version"
+	SERVER_CMD         = "server"
+	CLIENT_CMD         = "client"
+	CLIENT_LOCAL_PORT  = "8000"
+	CLIENT_LOCAL_HOST  = "localhost"
+	CLIENT_LOCAL_PROTO = "http"
+	SERVER_HTTP_PORT   = "3376"
+	SERVER_TCP_PORT    = "6673"
+	TUNNEL_HOST        = "mmar.dev"
+	TUNNEL_HTTP_PORT   = "443"
 
 	MMAR_ENV_VAR_SERVER_HTTP_PORT = "MMAR__SERVER_HTTP_PORT"
 	MMAR_ENV_VAR_SERVER_TCP_PORT  = "MMAR__SERVER_TCP_PORT"
 	MMAR_ENV_VAR_LOCAL_PORT       = "MMAR__LOCAL_PORT"
+	MMAR_ENV_VAR_LOCAL_HOST       = "MMAR__LOCAL_HOST"
+	MMAR_ENV_VAR_LOCAL_PROTO      = "MMAR__LOCAL_PROTO"
 	MMAR_ENV_VAR_TUNNEL_HTTP_PORT = "MMAR__TUNNEL_HTTP_PORT"
 	MMAR_ENV_VAR_TUNNEL_TCP_PORT  = "MMAR__TUNNEL_TCP_PORT"
 	MMAR_ENV_VAR_TUNNEL_HOST      = "MMAR__TUNNEL_HOST"
@@ -25,10 +29,12 @@ const (
 	SERVER_HTTP_PORT_HELP = "Define port where mmar will bind to and run on server for HTTP requests."
 	SERVER_TCP_PORT_HELP  = "Define port where mmar will bind to and run on server for TCP connections."
 
-	CLIENT_LOCAL_PORT_HELP = "Define the port where your local dev server is running to expose through mmar."
-	CLIENT_HTTP_PORT_HELP  = "Define port of mmar HTTP server to make requests through the tunnel."
-	CLIENT_TCP_PORT_HELP   = "Define port of mmar TCP server for client to connect to, creating a tunnel."
-	TUNNEL_HOST_HELP       = "Define host domain of mmar server for client to connect to."
+	CLIENT_LOCAL_PORT_HELP  = "Define the port where your local dev server is running to expose through mmar."
+	CLIENT_LOCAL_HOST_HELP  = "Define the hostname where your local dev server is running to expose through mmar."
+	CLIENT_LOCAL_PROTO_HELP = "Define the protocol where your local dev server is running to expose (http / https)."
+	CLIENT_HTTP_PORT_HELP   = "Define port of mmar HTTP server to make requests through the tunnel."
+	CLIENT_TCP_PORT_HELP    = "Define port of mmar TCP server for client to connect to, creating a tunnel."
+	TUNNEL_HOST_HELP        = "Define host domain of mmar server for client to connect to."
 
 	TUNNEL_MESSAGE_PROTOCOL_VERSION = 3
 	TUNNEL_MESSAGE_DATA_DELIMITER   = '\n'

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
 module github.com/yusuf-musleh/mmar
 
 go 1.23.0
+

--- a/internal/client/main.go
+++ b/internal/client/main.go
@@ -23,6 +23,8 @@ import (
 
 type ConfigOptions struct {
 	LocalPort      string
+	LocalHost      string
+	LocalProto     string
 	TunnelHttpPort string
 	TunnelTcpPort  string
 	TunnelHost     string
@@ -36,7 +38,7 @@ type MmarClient struct {
 }
 
 func (mc *MmarClient) localizeRequest(request *http.Request) {
-	localhost := fmt.Sprintf("http://localhost:%v%v", mc.LocalPort, request.RequestURI)
+	localhost := fmt.Sprintf("%v://%v:%v%v", mc.LocalProto, mc.LocalHost, mc.LocalPort, request.RequestURI)
 	localURL, urlErr := url.Parse(localhost)
 	if urlErr != nil {
 		log.Fatalf("Failed to parse URL: %v", urlErr)
@@ -44,6 +46,7 @@ func (mc *MmarClient) localizeRequest(request *http.Request) {
 
 	// Set URL to send request to local server
 	request.URL = localURL
+	request.Host = mc.LocalHost
 	// Clear requestURI since it is now a client request
 	request.RequestURI = ""
 }
@@ -195,7 +198,7 @@ func (mc *MmarClient) ProcessTunnelMessages(ctx context.Context) {
 				} else {
 					mc.subdomain = tunnelSubdomain
 				}
-				logger.LogTunnelCreated(tunnelSubdomain, mc.TunnelHost, mc.TunnelHttpPort, mc.LocalPort)
+				logger.LogTunnelCreated(tunnelSubdomain, mc.TunnelHost, mc.TunnelHttpPort, mc.LocalProto, mc.LocalHost, mc.LocalPort)
 			case protocol.CLIENT_TUNNEL_LIMIT:
 				limit := logger.ColorLogStr(
 					constants.RED,

--- a/internal/logger/main.go
+++ b/internal/logger/main.go
@@ -163,12 +163,12 @@ func LogStartMmarClient(tunnelHost string, tunnelTcpPort string, tunnelHttpPort 
 	)
 }
 
-func LogTunnelCreated(subdomain string, tunnelHost string, tunnelHttpPort string, localPort string) {
+func LogTunnelCreated(subdomain string, tunnelHost string, tunnelHttpPort string, localProto string, localHost string, localPort string) {
 	logStr := `%s
 
 A mmar tunnel is now open on:
 
->>>  %s://%s.%s%s %s http://localhost:%s
+>>>  %s://%s.%s%s %s %s://%s:%s
 
 `
 	httpProtocol := "https"
@@ -192,6 +192,8 @@ A mmar tunnel is now open on:
 		tunnelHost,
 		tunnelHttpPortStr,
 		ColorLogStr(constants.GREEN, "->"),
+		localProto,
+		localHost,
 		localPort,
 	)
 }


### PR DESCRIPTION
I use Laravel Herd as my local webserver because you get local valid ssl and it's easy do use and update, and since it uses **nginx virtual hosts** to switch between the websites I was not able to proxy to the correct website:

Problem 1: I need to replace localhost with sitename.test
Problem 2: I need to replace http with https, it can work with http as well but it's nicer to use https

In this PR I added 2 new flags:
- `-local-proto` that should get http or https
- `-local-host` to enter the hostname, or virtual host you want to access

I ran the tests and it passes, but with a panic:
```
2025/06/23 20:53:56 [zirvkx] "POST /post HTTP/1.1" 408 28
2025/06/23 20:54:23 [zirvkx] "GET /long-running HTTP/1.1" 200 43
2025/06/23 20:54:23 http: panic serving 127.0.0.1:55290: crashing devserver
goroutine 186 [running]:
net/http.(*conn).serve.func1()
        /home/andrei/.local/opt/go-v1.23.4/src/net/http/server.go:1947 +0xbe
panic({0x749a40?, 0x8589b0?})
        /home/andrei/.local/opt/go-v1.23.4/src/runtime/panic.go:785 +0x132
github.com/yusuf-musleh/mmar/simulations/devserver.handleCrashingReq({0xc0002000a0?, 0x478632?}, 0xc000277b38?)
        /home/andrei/mmar/simulations/devserver/main.go:224 +0x25
net/http.HandlerFunc.ServeHTTP(0xc00016a0e0?, {0x85c9f0?, 0xc00016a1c0?}, 0x6e7e36?)
        /home/andrei/.local/opt/go-v1.23.4/src/net/http/server.go:2220 +0x29
net/http.(*ServeMux).ServeHTTP(0x46bf79?, {0x85c9f0, 0xc00016a1c0}, 0xc000170280)
        /home/andrei/.local/opt/go-v1.23.4/src/net/http/server.go:2747 +0x1ca
net/http.serverHandler.ServeHTTP({0xc000202390?}, {0x85c9f0?, 0xc00016a1c0?}, 0x6?)
        /home/andrei/.local/opt/go-v1.23.4/src/net/http/server.go:3210 +0x8e
net/http.(*conn).serve(0xc0000e6090, {0x85cdf0, 0xc0002020f0})
        /home/andrei/.local/opt/go-v1.23.4/src/net/http/server.go:2092 +0x5d0
created by net/http.(*Server).Serve in goroutine 21
        /home/andrei/.local/opt/go-v1.23.4/src/net/http/server.go:3360 +0x485
2025/06/23 20:54:23 [zirvkx] "GET /crash HTTP/1.1" 200 59
```
Or is this a normal test case scenario since the request was `GET /crash` ?

I am new to golang testing. How would I write a test for this new flags ?
To test the hostname change should I edit the /etc/hosts ? I think no.
Should I test using an external dns that resolves to localhost ? https://nip.io/ or https://sslip.io/